### PR TITLE
Add ability to get kernel version from header at runtime

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1,4 +1,5 @@
 #include <fcntl.h>
+#include <fstream>
 #include <iostream>
 #include <regex>
 #include <sys/utsname.h>
@@ -162,6 +163,22 @@ static unsigned kernel_version(int attempt)
       unsigned x, y, z;
       sscanf(utsname.release, "%d.%d.%d", &x, &y, &z);
       return (x << 16) + (y << 8) + z;
+    case 2:
+      // try to get the definition of LINUX_VERSION_CODE at runtime.
+      // needed if bpftrace is compiled on a different linux version than it's used on.
+      // e.g. if built with docker.
+      // the reason case 0 doesn't work for this is because it uses the preprocessor directive,
+      // which is by definition a compile-time constant
+      std::ifstream linux_version_header{"/usr/include/linux/version.h"};
+      const std::string content{std::istreambuf_iterator<char>(linux_version_header),
+                                std::istreambuf_iterator<char>()};
+      const std::regex regex{"#define\\s+LINUX_VERSION_CODE\\s+(\\d+)"};
+      std::smatch match;
+
+      if (std::regex_search(content.begin(), content.end(), match, regex))
+        return static_cast<unsigned>(std::stoi(match[1]));
+
+      return 0;
   }
 }
 
@@ -182,7 +199,7 @@ void AttachedProbe::load_prog()
   dup2(new_stderr, 2);
   close(new_stderr);
 
-  for (int attempt=0; attempt<2; attempt++)
+  for (int attempt=0; attempt<3; attempt++)
   {
     progfd_ = bpf_prog_load(progtype(probe_.type), probe_.name.c_str(),
         reinterpret_cast<struct bpf_insn*>(insns), prog_len, license,

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -162,7 +162,7 @@ static unsigned kernel_version(int attempt)
       uname(&utsname);
       unsigned x, y, z;
       sscanf(utsname.release, "%d.%d.%d", &x, &y, &z);
-      return (x << 16) + (y << 8) + z;
+      return KERNEL_VERSION(x, y, z);
     case 2:
       // try to get the definition of LINUX_VERSION_CODE at runtime.
       // needed if bpftrace is compiled on a different linux version than it's used on.


### PR DESCRIPTION
After a build using docker, I was getting this error:
```
# build-debug/src/bpftrace -e 'kprobe:sys_nanosleep { printf("%u: sleep by %d\n", nsecs, tid); }'
Attaching 1 probe...
Error loading program: kprobe:sys_nanosleep
```

strace to the rescue:
```
# strace build-debug/src/bpftrace -e 'kprobe:sys_nanosleep { printf("%u: sleep by %d\n", nsecs, tid); }'
*snip*
bpf(BPF_PROG_LOAD, {prog_type=BPF_PROG_TYPE_KPROBE, insn_cnt=21, insns=0x7f48b7d51000, license="GPL", log_level=0, log_size=0, log_buf=0, kern_version=266001}, 72) = -1 E2BIG (Argument list too long)
bpf(BPF_PROG_LOAD, {prog_type=BPF_PROG_TYPE_KPROBE, insn_cnt=21, insns=0x7f48b7d51000, license="GPL", log_level=0, log_size=0, log_buf=0, kern_version=266001}, 72) = -1 EINVAL (Invalid argument)
brk(0x22f9000)                          = 0x22f9000
bpf(BPF_PROG_LOAD, {prog_type=BPF_PROG_TYPE_KPROBE, insn_cnt=21, insns=0x7f48b7d51000, license="GPL", log_level=1, log_size=65536, log_buf=0x22c8c50, kern_version=266001}, 72) = -1 EINVAL (Invalid argument)
write(2, "bpf: Failed to load program: Inv"..., 46) = 46
write(2, "\n", 1)                       = 1
brk(0x22e9000)                          = 0x22e9000
uname({sysname="Linux", nodename="factotum", ...}) = 0
bpf(BPF_PROG_LOAD, {prog_type=BPF_PROG_TYPE_KPROBE, insn_cnt=21, insns=0x7f48b7d51000, license="GPL", log_level=0, log_size=0, log_buf=0, kern_version=265472}, 72) = -1 E2BIG (Argument list too long)
bpf(BPF_PROG_LOAD, {prog_type=BPF_PROG_TYPE_KPROBE, insn_cnt=21, insns=0x7f48b7d51000, license="GPL", log_level=0, log_size=0, log_buf=0, kern_version=265472}, 72) = -1 EINVAL (Invalid argument)
bpf(BPF_PROG_LOAD, {prog_type=BPF_PROG_TYPE_KPROBE, insn_cnt=21, insns=0x7f48b7d51000, license="GPL", log_level=1, log_size=65536, log_buf=0x22c8c50, kern_version=265472}, 72) = -1 EINVAL (Invalid argument)
write(2, "bpf: Failed to load program: Inv"..., 46) = 46
```
It's trying different kernel versions and getting a `-EINVAL`. Checking the source code for [`bpf_prog_load()`](https://elixir.bootlin.com/linux/v4.14.24/source/kernel/bpf/syscall.c#L978), I see that one of the ways for that function to return `-EINVAL` is if the given `kern_version` doesn't match the definition of `LINUX_VERSION_CODE` in `/usr/include/linux/version.h` (or wherever this header is).

This happens because my docker image has a different kernel version than my machine, and bpftrace uses the `LINUX_VERSION_CODE` macro in its version getter (preprocessing is a compile-time operation).  This patch adds the ability for bpftrace to get the value of `LINUX_VERSION_CODE` at runtime, which is what we need to do if we want to run bpftrace on a different kernel version than it was compiled on.